### PR TITLE
Fix missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     },
     install_requires=[
         'cchardet;python_version<\'3.10\'',
-        'faust-cchardet;python_version>=\'3.10\''
+        'faust-cchardet;python_version>=\'3.10\'',
         'pysubs2',
         'PyQt5'
     ],


### PR DESCRIPTION
I'm trying to use rubysubs on python 3.11 and found the error with setup.py.
It's missing a comma and cannot be installed.

Hopefully, this should propagate and show up on the original pull request at https://github.com/RicBent/rubysubs/pull/4https://github.com/RicBent/rubysubs/pull/4